### PR TITLE
Reduce verbosity of middleware logging

### DIFF
--- a/api/middleware.go.tmpl
+++ b/api/middleware.go.tmpl
@@ -47,18 +47,19 @@ func TokenMiddleware(psk []byte, public map[string]string, h http.Handler) http.
 		}
 
 		if _, ok := public[uri.Path]; ok {
-			log.Infof("Not authenticating for '%s'", uri.Path)
+			log.Debugf("Not authenticating for '%s'", uri.Path)
 		} else {
-			log.Infof("Authenticating token for protected URL '%s'", r.URL)
+			log.Debugf("Authenticating token for protected URL '%s'", r.URL)
 
 			htoken := r.Header.Get("X-Auth-Token")
 			if err := bcrypt.CompareHashAndPassword([]byte(htoken), psk); err != nil {
-				log.Warnf("Unable to authenticate session for URL '%s' with error '%s'", r.URL, err)
+				log.Warnf("Unable to authenticate session for URL '%s': '%s'", r.URL, err)
 				w.WriteHeader(http.StatusForbidden)
 				return
 			}
+
+			log.Infof("Successfully authenticated token for URL '%s'", r.URL)
 		}
-		log.Infof("Successfully authenticated token for URL '%s'", r.URL)
 
 		h.ServeHTTP(w, r)
 	})


### PR DESCRIPTION
To make it easier to grok the logging, stop logging 3 lines for every ping check.